### PR TITLE
Feature/independent badge rendering

### DIFF
--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -9,7 +9,6 @@ use Drupal\user\Entity\User;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-
 use Drupal\summergame\Helper\BadgeRenderer;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Drupal\Component\Serialization\Json;

--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -702,7 +702,6 @@ class PlayerController extends ControllerBase {
       $module_path = \Drupal::service('module_handler')->getModule('summergame')->getpath();
       $html = $this->renderTwig($module_path."/templates/sg-badge-display-embed.html.twig",  $renderArray);
       $resp->html[$key] = $html;
-      $resp->data[$key] = $badgeData;
     }
     $response = new JsonResponse($resp, 200);
     return $response;

--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -658,7 +658,6 @@ class PlayerController extends ControllerBase {
     $session = \Drupal::request()->getSession();
     $recently_viewed_badges = $session->get('recently_viewed_badges');
     $resp = json_decode("{}");
-    $resp->data = [];
 
     foreach($recently_viewed_badges as $key=>$value){
 

--- a/src/Helper/BadgeRenderer.php
+++ b/src/Helper/BadgeRenderer.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Drupal\summergame\Helper;
+
+/**
+ * Class BadgeRenderer
+ * @package Drupal\summergame\Helper
+ */
+class BadgeRenderer {
+
+  function __construct(){}
+
+   /**
+   * @return array
+   */
+
+  static function abstractSGBadgeRender($variables){
+
+  $variables['test_data'] = "Some data";
+
+  $badge_level = $variables['node']->field_badge_level->value;
+  switch ($badge_level) {
+    case 2:
+      $variables['badge_level'] = "⭐️⭐️ Tricky";
+      break;
+    case 3:
+      $variables['badge_level'] = "⭐️⭐️⭐️ Super Tricky";
+      break;
+    case 4:
+        $variables['badge_level'] = "⭐️⭐️⭐️⭐️ Ambitious";
+        break;
+    default:
+      $variables['badge_level'] = "⭐️ Standard";
+  }
+
+  // set up badge progress display
+  if (\Drupal::moduleHandler()->moduleExists('summergame')) {
+    $sg_enabled = \Drupal::config('summergame.settings')->get('summergame_points_enabled');
+    $user = \Drupal::currentUser();
+
+    $db = \Drupal::database();
+    $awarded = $db->query("SELECT COUNT(pid) AS pcount FROM sg_players_badges WHERE bid=:bid", [':bid' => $variables['node']->id()])->fetch();
+    $variables['badge_awards'] = "This badge has been awarded to $awarded->pcount players";
+
+    // Prepare taxonomy terms
+    $variables['badge_series'] = [];
+    $play_test_term_id = \Drupal::config('summergame.settings')->get('summergame_play_test_term_id');
+    if (isset($variables['node']->field_sg_badge_series_multiple)) {
+      foreach ($variables['node']->field_sg_badge_series_multiple->referencedEntities() as $ref) {
+        $tid = $ref->get('tid')->value;
+        if ($tid != $play_test_term_id) {
+          $variables['badge_series'][$tid] = $ref->get('name')->value;
+        }
+      }
+    }
+    $variables['badge_tags'] = [];
+    if (isset($variables['node']->field_badge_tags)) {
+      foreach ($variables['node']->field_badge_tags->referencedEntities() as $ref) {
+        $tid = $ref->get('tid')->value;
+        $variables['badge_tags'][$tid] = $ref->get('name')->value;
+      }
+    }
+
+    $badge_progress = '';
+    $badge_list = '';
+    if ($user->isAuthenticated()) {
+      if (summergame_get_active_player() || $user->hasPermission('administer summergame')) {
+        if ($user->hasPermission('administer summergame') && isset($_GET['pid'])) {
+          $pid = $_GET['pid'];
+          $player = summergame_player_load(['pid' => $pid]);
+        } else {
+          $player = summergame_get_active_player();
+          $pid = $player['pid'];
+        }
+
+        $variables['redeem_form'] = \Drupal::formBuilder()->getForm('Drupal\summergame\Form\SummerGamePlayerRedeemForm', $pid);
+
+        $badge = new \StdClass();
+        $badge->game_term = $variables['node']->field_badge_game_term->value;
+        $badge->level = $variables['node']->field_badge_level->value;
+        $badge->formula = $variables['node']->field_badge_formula->value;
+        $badge->points = $variables['node']->field_badge_points->value;
+        $badge->reveal = $variables['node']->field_badge_reveal->value;
+
+        $player_badge_status = '<p class="player-badge-status">';
+        $earned = $db->query("SELECT * FROM sg_players_badges WHERE pid=:pid AND bid=:bid", [':pid' => $pid, ':bid' => $variables['node']->id()])->fetch();
+        if (!empty($earned->timestamp)) {
+          $player_badge_status .= 'You received this badge on ' . date('F j, Y g:i A', $earned->timestamp);
+
+              // $share_links .= '<div class="share-links">';
+
+              // $share_links .= '<div>Share your accomplishment:</div>';
+
+              // $share_links .= '<div class="twitter-share">';
+              // $share_links .= '<script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>';
+              // $share_links .= '<a href="http://twitter.com/share/?url=/" class="twitter-share-button" data-text="I earned the ' .
+              //                         $badge->title . ' Badge in the @aadl #summergame! ' . url($_GET['q'], array('absolute' => TRUE)) .
+              //                         ' Play along at http://play.aadl.org/." data-count="none">Tweet</a>';
+              // $share_links .= '</div>';
+
+              // $share_links .= '<div class="facebook-share">';
+              //         $share_links .= <<<FBL
+              // <div id="fb-root"></div>
+              // <script>(function(d, s, id) {
+              //   var js, fjs = d.getElementsByTagName(s)[0];
+              //   if (d.getElementById(id)) return;
+              //   js = d.createElement(s); js.id = id;
+              //   js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
+              //   fjs.parentNode.insertBefore(js, fjs);
+              // }(document, 'script', 'facebook-jssdk'));</script>
+              // <fb:like send="false" layout="standard" width="225" show_faces="true" colorscheme="light" action="like"></fb:like>
+              // FBL;
+              // $share_links .= '</div>';
+
+              // $share_links .= '</div>';
+
+              // $player_badge_status .= $share_links;
+        }
+        else {
+          $player_badge_status .= 'You have not yet earned this badge';
+        }
+        $player_badge_status .= '</p>';
+
+        // Handle hidden badges
+        $variables['hide_badge'] = FALSE;
+        if ($badge->reveal) {
+          if ($pid) {
+            $required_parts = explode(',', $badge->reveal);
+            foreach ($required_parts as $required_part) {
+              if (strpos($required_part, 'gamecode:') === 0) {
+                // Required Game Code, search player ledger
+                $ledger = $db->query("SELECT * FROM sg_ledger WHERE pid = :pid AND metadata LIKE :metadata AND game_term = :term LIMIT 1",
+                                                   [':pid' => $pid, ':metadata' => $required_part, ':term' => $badge->game_term])->fetch();
+                if (!$ledger->lid) {
+                  $variables['hide_badge'] = TRUE;
+                  break;
+                }
+              }
+              else {
+                // Required Badge
+                if (!$player['bids'][$required_part]) {
+                  $variables['hide_badge'] = TRUE;
+                  break;
+                }
+              }
+            }
+            $variables['elements']['#title'] = 'Hidden Badge';
+          }
+          else {
+            // no player
+            $variables['hide_badge'] = TRUE;
+          }
+        }
+
+        if ($badge->points) {
+          $term = ($badge->game_term_override ?? $badge->game_term);
+          $points = ($badge->points_override ?? $badge->points);
+        }
+
+        if (!$variables['hide_badge']) {
+          $player_count = 0;
+          if (strpos($badge->formula, '**') !== FALSE) {
+            // Multi Game Term ("Hall of Fame") Badge
+            list($hof_type, $game_term_pattern, $total_count) = explode('**', $badge->formula);
+            if ($hof_type == 'game_terms') {
+              $formula_type = '"' . $game_term_pattern . '" games played';
+              // Count distict Game Terms that match the pattern
+              $gt_count = $db->query("SELECT COUNT(DISTINCT `game_term`) AS gt_count FROM `sg_ledger` WHERE `pid` = $pid AND `game_term` LIKE :game_term_pattern",
+                                     [':game_term_pattern' => "%$game_term_pattern%"])->fetchObject();
+              $player_count = $gt_count->gt_count;
+            }
+            elseif ($hof_type == 'total_points') {
+              $formula_type = '"' . $game_term_pattern . '" total points';
+              $point_total = $db->query("SELECT SUM(`points`) AS point_total FROM `sg_ledger` WHERE `pid` = $pid AND `game_term` LIKE :game_term_pattern " .
+                                        "AND `points` > '0' AND `metadata` NOT LIKE '%leaderboard:no%'",
+                                        [':game_term_pattern' => "%$game_term_pattern%"])->fetchObject();
+              $player_count = $point_total->point_total;
+            }
+          }
+          elseif (preg_match('/^{([\d,]+)}$/', $badge->formula, $matches)) {
+            // Badge collection badge
+            $formula_type = ' badges earned';
+            $bids = explode(',', $matches[1]);
+            $total_count = count($bids);
+            $badge_list = '';
+            foreach ($bids as $bid) {
+              $node = Node::load($bid);
+              $faded_class = (isset($player['bids'][$bid]) ? '' : ' sg-badge-faded');
+              $badge_list .= '<a href="/node/' . $bid . '" target="_blank">' .
+                             '<img class="sg-admin-badge ' . $faded_class . '" src="/files/badge-derivs/100/' . $node->field_badge_image->entity->getFilename() . '">' .
+                             '</a>';
+            }
+            $badge_count = $db->query("SELECT COUNT(bid) AS bid_count FROM sg_players_badges WHERE pid=:pid AND bid IN (" . implode(',', $bids) . ")", [':pid' => $pid])->fetch();
+            $player_count = $badge_count->bid_count;
+          }
+          else if (strpos($badge->formula, '^^') !== FALSE) {
+            // Multiple Day Badge (Streak)
+            list($total_count, $text_pattern) = explode('^^', $badge->formula);
+            $lid_count = $db->query("SELECT COUNT(DISTINCT FROM_UNIXTIME(`timestamp`, '%j')) AS lid_count FROM sg_ledger WHERE pid=:pid AND (type LIKE :type OR metadata LIKE :metadata) AND game_term = :term",
+                                    [':pid' => $pid, ':type' => $text_pattern, ':metadata' => 'gamecode:'.$text_pattern, ':term' => $badge->game_term])->fetch();
+
+            $player_count = $lid_count->lid_count;
+            $formula_type = " days with a " . $text_pattern . " score in your ledger";
+          }
+          else if (strpos($badge->formula, '::') !== FALSE) {
+            // Multiple Badge
+            $formula_parts = explode('::', $badge->formula);
+            if (count($formula_parts) == 2) {
+              list($total_count, $text_pattern) = explode('::', $badge->formula);
+              $lid_count = $db->query("SELECT COUNT(lid) AS lid_count FROM sg_ledger WHERE pid=:pid AND (type LIKE :type OR metadata LIKE :metadata) AND game_term = :term",
+                                                      [':pid' => $pid, ':type' => $text_pattern, ':metadata' => 'gamecode:'.$text_pattern, ':term' => $badge->game_term])->fetch();
+            }
+            else if (count($formula_parts) == 3) {
+              // New multiple of a ledger pattern (count::field::pattern)
+              list($total_count, $ledger_field, $text_pattern) = $formula_parts;
+              $lid_count = $db->query("SELECT COUNT(lid) AS lid_count FROM sg_ledger WHERE pid = $pid " .
+                                      'AND game_term = :game_term ' .
+                                      "AND $ledger_field LIKE :text_pattern",
+                                      [':game_term' => $badge->game_term, ':text_pattern' => $text_pattern])->fetchObject();
+            }
+            $player_count = $lid_count->lid_count;
+            $formula_type = $text_pattern . " scores in your ledger";
+          }
+          else {
+            // Collection Badge
+            $formula_type = ' criteria';
+            $codes = explode(',', $badge->formula);
+            $total_count = count($codes);
+            $player_matches = array();
+            $gc_rows = array();
+
+            foreach ($codes as $code_id => $text_pattern) {
+              $text_patterns = explode('|', $text_pattern);
+              if (count($text_patterns) > 1) {
+                $gc_rows[] = array('game_code' => '<strong>One of the following:</strong>',
+                                   'description' => '',
+                                   'earned_on' => '');
+                $any_mode = TRUE;
+              }
+              else {
+                $any_mode = FALSE;
+              }
+
+              foreach ($text_patterns as $pattern) {
+                $gc_row = array('game_code' => '',
+                                'description' => '',
+                                'earned_on' => '');
+
+                // is it a game code?
+                $gc = $db->query("SELECT * FROM sg_game_codes WHERE text = :text", [':text' => $pattern])->fetch();
+                if (isset($gc->code_id)) {
+                  $formula_type = ' game codes found';
+                  $gc_row['game_code'] = '???????';
+                  $gc_row['clue'] = $gc->clue;
+                  $clue_trigger = $gc->clue_trigger;
+                  if (empty($clue_trigger)) {
+                    $gc_row['clue_unlocked'] = true;
+                  } else {
+                    $clue_unlocked = $db->query("SELECT * FROM sg_ledger WHERE pid = :pid AND metadata = :metadata AND game_term = :term LIMIT 1", [':pid' => $pid, ':metadata' => 'gamecode:'.$clue_trigger, ':term' => $badge->game_term])->fetch();
+                    $gc_row['clue_unlocked'] = (isset($clue_unlocked->lid) ? true : false);
+                  }
+                  if ($hint = $gc->hint) {
+                    $hint = str_replace('\'', '\x27', str_replace('"', '\x22', $hint));
+                    $replace_lines = ["\n", "\r\n", "\r"];
+                    $hint = str_replace($replace_lines, '', $hint);
+                    if ($gc_row['clue_unlocked']) {
+                      $gc_row['description'] = "<span style=\"color:#06c;\" onclick=\"this.innerHTML = 'HINT: $hint'; this.style.color='black';\">(click for hint)</span>";
+                    } else {
+                      $gc_row['description'] = 'You have not unlocked this hint';
+                    }
+                  }
+                }
+                else {
+                  // not a game code
+                  $gc_row['game_code'] = $pattern;
+                }
+
+                $ledger = $db->query("SELECT * FROM sg_ledger WHERE pid = :pid AND (type LIKE :type OR metadata LIKE :metadata) AND game_term = :term LIMIT 1",
+                                                   [':pid' => $pid, ':type' => $pattern, ':metadata' => 'gamecode:'.$pattern, ':term' => $badge->game_term])->fetch();
+                if (isset($ledger->lid)) {
+                  if (!$player_matches[$code_id]) {
+                    $player_count++;
+                    $player_matches[$code_id] = TRUE;
+                  }
+                  if ($gc->code_id) {
+                    $gc_row['game_code'] = $gc->text;
+                    $gc_row['description'] = $gc->description;
+                  }
+                  $gc_row['earned_on'] = date('F j, Y, g:i a', $ledger->timestamp);
+                }
+
+                if ($any_mode) {
+                  $gc_row['Game Code'] = '-- ' . $gc_row['Game Code'];
+                }
+                $gc_rows[] = $gc_row;
+              }
+            }
+          }
+
+          $badge_progress = '';
+          if ($pid) {
+            // Show progress bar
+            if ($player_count) {
+              $percentage = min(round(($player_count / $total_count) * 100), 100);
+            }
+            else {
+              $percentage = 0;
+            }
+            $badge_progress .= '<h3>Player ' . ($player['nickname'] ? $player['nickname'] : $player['name']);
+            $badge_progress .= " Progress: $percentage% ($player_count / $total_count $formula_type)</h3>";
+            $badge_progress .= "<progress class=\"sg-badge-progress-bar\" value=\"$percentage\" max=\"100\"></progress><br>";
+            $badge_progress .= $player_badge_status;
+          }
+
+          if (!empty($gc_rows)) {
+            $variables['gc_rows'] = $gc_rows;
+          }
+
+          if ($badge_list) {
+            $badge_progress .= '<div class="badge-collection-list">';
+            $badge_progress .= '<h3>Required Badges:</h3>';
+            $badge_progress .= '<div id="summergame-badges-page">';
+            $badge_progress .= $badge_list;
+            $badge_progress .= '</div>';
+            $badge_progress .= '</div>';
+          }
+        } // end of hide badge check
+
+        $variables['badge_progress'] = $badge_progress;
+      } else {
+        $variables['badge_progress'] = '<h3>You don\'t have a player on this account. <a href="/summergame/player">Create one now</a>!</h3>';
+      }
+    }
+  }
+  $variables['#cache']['max-age'] = 0;
+  $variables['game_display_name'] = \Drupal::config('summergame.settings')->get('game_display_name');
+
+  return $variables;
+
+  }
+}

--- a/summergame.routing.yml
+++ b/summergame.routing.yml
@@ -315,3 +315,10 @@ summergame.trivia.update:
     _title: 'Summer Game Trivia Update'
   requirements:
     _permission: 'access summergame'
+summergame.recent.badges:
+  path: '/summergame/recent-badges'
+  defaults:
+    _controller: '\Drupal\summergame\Controller\PlayerController::getRecentBadges'
+    _title: 'Summer Game Recent Badges'
+  requirements:
+    _permission: 'access summergame'

--- a/templates/sg-badge-display-embed.html.twig
+++ b/templates/sg-badge-display-embed.html.twig
@@ -1,0 +1,54 @@
+
+
+<article>
+        <h1 class="no-margin">{{ badge.hide_badge ? 'Hidden Badge' : badge_node.title.value }}</h1>
+        
+        {% if badge.hide_badge %}
+          <p>This badge is hidden and needs another action to unlock it.</p>
+        {% else %}
+          <p>{{ badge.parsed_body }}</p>
+          <div id="badge-progress">
+            <p>{{ badge.badge_awards }}</p>
+            {% if badge.logged_in %}
+              <p>
+                {{ badge.badge_progress|raw }}
+                {% if badge.gc_rows %}
+                  <table id="gc_rows">
+                    <thead>
+                      <tr>
+                        <th>Game Code</th>
+                        <th>Description</th>
+                        <th>Earned On</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for row in badge.gc_rows %}
+                        {% if row.clue %}
+                          <tr {% if loop.index is even %}class="sg-code-row-pair"{% endif %}>
+                            <td colspan="3">
+                              {% if row.clue_unlocked %}
+                                Clue: {{ row.clue|raw }}
+                              {% else %}
+                                Clue not unlocked
+                              {% endif %}
+                            </td>
+                          </tr>
+                        {% endif %}
+                        <tr {% if loop.index is even %}class="sg-code-row-pair"{% endif %}>
+                          <td>{{ row.game_code|raw }}</td>
+                          <td>{{ row.description|raw }}</td>
+                          <td>{{ row.earned_on }}</td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                {% endif %}
+              </p>
+            {% else %}
+              <p><a href="/user/login?destination={{ path('<current>')|url_encode }}">Sign in</a> to see clues and check your progress on this badge</p>
+            {% endif %}
+          </div>
+        {% endif %}
+        
+      <a class="slideout-badge-link" href="{{ badge_url }}">Go to full badge page</a>
+  </article>


### PR DESCRIPTION
@ejk This PR is benign on its own and does not change existing functionality.  I'm basically recreating a the badge functionality from the aadl theme and abstracting into a helper, so on its own all this branch does is add that code and make badge rendering available in a new endpoint.  The existing functionality changes will come in a later PR to the theme.

To test, you can view a couple badge pages, then go to `/summergame/recent-badges`