### PR TITLE
Handle scatterlog connections

### DIFF
--- a/src/Controller/ConnectionController.php
+++ b/src/Controller/ConnectionController.php
@@ -2,49 +2,44 @@
 
 /**
  * @file
- * Contains \Drupal\summergame\Controller\TriviaController.
+ * Contains \Drupal\summergame\Controller\ConnectionController.
  */
 
 namespace Drupal\summergame\Controller;
 
-use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-
-//use Drupal\Core\Database\Database;
-//use Drupal\Core\Url;
 
 /**
  * External connection controller for the Summer Game module.
  */
 class ConnectionController extends PlayerController
 {
-	public function show()
-	{
-		$user = \Drupal::currentUser();
-		if (!$user->isAuthenticated()) {
-			return new RedirectResponse('/user/login?destination=/summergame/scatterlog/connect');
-		}
-		$uid = $user->id();
-		$db = \Drupal::database();
-		$result = $db->query('SELECT * FROM sg_players WHERE uid = ' . (int) $uid . ' ORDER BY pid ASC');
-		$players = [];
-		while ($player = $result->fetchAssoc()) {
-			$players[] = $player;
-		}
-		return [
-			'#cache' => [
-				'max-age' => 0, // Don't cache, always get fresh data
-			],
-			'#theme' => 'summergame_player_external_redeem',
-			'#uid' => $uid,
-			'#players' => $players,
-		];
-	}
-	public function connect($uid)
-	{
-		$scatterlogKey = \Drupal::config('summergame.settings')->get('summergame_scatterlog_key');
-		return new TrustedRedirectResponse(\Drupal::config('summergame.settings')->get('summergame_scatterlog_url') . '/connect?uid=' . $uid . '&key=' . $scatterlogKey);
-	}
+  public function show()
+  {
+    $user = \Drupal::currentUser();
+    if (!$user->isAuthenticated()) {
+      return new RedirectResponse('/user/login?destination=/summergame/scatterlog/connect');
+    }
+    $uid = $user->id();
+    $db = \Drupal::database();
+    $result = $db->query('SELECT * FROM sg_players WHERE uid = ' . (int) $uid . ' ORDER BY pid ASC');
+    $players = [];
+    while ($player = $result->fetchAssoc()) {
+      $players[] = $player;
+    }
+    return [
+      '#cache' => [
+        'max-age' => 0, // Don't cache, always get fresh data
+      ],
+      '#theme' => 'summergame_player_external_redeem',
+      '#uid' => $uid,
+      '#players' => $players,
+    ];
+  }
+  public function connect($uid)
+  {
+    $scatterlogKey = \Drupal::config('summergame.settings')->get('summergame_scatterlog_key');
+    return new TrustedRedirectResponse(\Drupal::config('summergame.settings')->get('summergame_scatterlog_url') . '/connect?uid=' . $uid . '&key=' . $scatterlogKey);
+  }
 }

--- a/src/Controller/ConnectionController.php
+++ b/src/Controller/ConnectionController.php
@@ -38,14 +38,13 @@ class ConnectionController extends PlayerController
 				'max-age' => 0, // Don't cache, always get fresh data
 			],
 			'#theme' => 'summergame_player_external_redeem',
+			'#uid' => $uid,
 			'#players' => $players,
 		];
 	}
-	public function connect($pid)
+	public function connect($uid)
 	{
 		$shelveItKey = \Drupal::config('summergame.settings')->get('summergame_shelveit_key');
-		$db = \Drupal::database();
-		$result = $db->query('SELECT * FROM sg_players WHERE pid = ' . (int) $pid)->fetch();
-		return new TrustedRedirectResponse('http://shelve-it.aadldev.test/connect?pid=' . $pid . '&nickname=' . $result->nickname . '&key=' . $shelveItKey);
+		return new TrustedRedirectResponse('http://shelve-it.aadldev.test/connect?uid=' . $uid . '&key=' . $shelveItKey);
 	}
 }

--- a/src/Controller/ConnectionController.php
+++ b/src/Controller/ConnectionController.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\summergame\Controller\TriviaController.
+ */
+
+namespace Drupal\summergame\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+//use Drupal\Core\Database\Database;
+//use Drupal\Core\Url;
+
+/**
+ * External connection controller for the Summer Game module.
+ */
+class ConnectionController extends PlayerController
+{
+	public function show()
+	{
+		$user = \Drupal::currentUser();
+		if (!$user->isAuthenticated()) {
+			return new RedirectResponse('/user/login?destination=/summergame/shelveit/connect');
+		}
+		$uid = $user->id();
+		$db = \Drupal::database();
+		$result = $db->query('SELECT * FROM sg_players WHERE uid = ' . (int) $uid . ' ORDER BY pid ASC');
+		$players = [];
+		while ($player = $result->fetchAssoc()) {
+			$players[] = $player;
+		}
+		return [
+			'#cache' => [
+				'max-age' => 0, // Don't cache, always get fresh data
+			],
+			'#theme' => 'summergame_player_external_redeem',
+			'#players' => $players,
+		];
+	}
+	public function connect($pid)
+	{
+		$shelveItKey = \Drupal::config('summergame.settings')->get('summergame_shelveit_key');
+		$db = \Drupal::database();
+		$result = $db->query('SELECT * FROM sg_players WHERE pid = ' . (int) $pid)->fetch();
+		return new TrustedRedirectResponse('http://shelve-it.aadldev.test/connect?pid=' . $pid . '&nickname=' . $result->nickname . '&key=' . $shelveItKey);
+	}
+}

--- a/src/Controller/ConnectionController.php
+++ b/src/Controller/ConnectionController.php
@@ -24,7 +24,7 @@ class ConnectionController extends PlayerController
 	{
 		$user = \Drupal::currentUser();
 		if (!$user->isAuthenticated()) {
-			return new RedirectResponse('/user/login?destination=/summergame/shelveit/connect');
+			return new RedirectResponse('/user/login?destination=/summergame/scatterlog/connect');
 		}
 		$uid = $user->id();
 		$db = \Drupal::database();
@@ -44,7 +44,7 @@ class ConnectionController extends PlayerController
 	}
 	public function connect($uid)
 	{
-		$shelveItKey = \Drupal::config('summergame.settings')->get('summergame_shelveit_key');
-		return new TrustedRedirectResponse('http://shelve-it.aadldev.test/connect?uid=' . $uid . '&key=' . $shelveItKey);
+		$scatterlogKey = \Drupal::config('summergame.settings')->get('summergame_scatterlog_key');
+		return new TrustedRedirectResponse(\Drupal::config('summergame.settings')->get('summergame_scatterlog_url') . '/connect?uid=' . $uid . '&key=' . $scatterlogKey);
 	}
 }

--- a/src/Form/SummerGameAdminForm.php
+++ b/src/Form/SummerGameAdminForm.php
@@ -200,16 +200,16 @@ class SummerGameAdminForm extends ConfigFormBase {
       '#description' => 'Message to be displayed under the player shop balance when current points is greater than current point threshold',
     ];
     $form['game_display_name'] = [
-        '#type' => 'textfield',
-        '#title' => 'Game Display Name',
-        '#default_value' => $summergame_settings->get('game_display_name'),
-        '#description' => 'The name to be displayed throughout the SummerGame UI',
+      '#type' => 'textfield',
+      '#title' => 'Game Display Name',
+      '#default_value' => $summergame_settings->get('game_display_name'),
+      '#description' => 'The name to be displayed throughout the SummerGame UI',
     ];
     $form['summergame_homecode_geocode_url'] = [
-        '#type' => 'textfield',
-        '#title' => 'Home Code Geocode URL',
-        '#default_value' => $summergame_settings->get('summergame_homecode_geocode_url'),
-        '#description' => 'URL Address of Geocoding Service for Home Code address lookup (e.g. https://maps.googleapis.com/maps/api/geocode/json)',
+      '#type' => 'textfield',
+      '#title' => 'Home Code Geocode URL',
+      '#default_value' => $summergame_settings->get('summergame_homecode_geocode_url'),
+      '#description' => 'URL Address of Geocoding Service for Home Code address lookup (e.g. https://maps.googleapis.com/maps/api/geocode/json)',
     ];
     $form['summergame_homecode_geocode_api_key'] = [
       '#type' => 'textfield',
@@ -218,10 +218,10 @@ class SummerGameAdminForm extends ConfigFormBase {
       '#description' => 'API Key for Geocoding Service for Home Code address lookup',
     ];
     $form['summergame_homecode_notify_email'] = [
-        '#type' => 'textfield',
-        '#title' => 'Home Code Notify Email',
-        '#default_value' => $summergame_settings->get('summergame_homecode_notify_email'),
-        '#description' => 'Email address to send notifications of new home codes',
+      '#type' => 'textfield',
+      '#title' => 'Home Code Notify Email',
+      '#default_value' => $summergame_settings->get('summergame_homecode_notify_email'),
+      '#description' => 'Email address to send notifications of new home codes',
     ];
     $form['summergame_homecode_message'] = [
       '#type' => 'textarea',
@@ -235,8 +235,14 @@ class SummerGameAdminForm extends ConfigFormBase {
       '#default_value' => $summergame_settings->get('summergame_homecode_report_threshold'),
       '#description' => 'Number of player reports needed to remove a Home Code from the map',
     ];
+    $form['summergame_shelveit_key'] =
+      [
+        '#type' => 'textfield',
+        '#title' => 'Shelve It App Key',
+        '#default_value' => $summergame_settings->get('summergame_shelveit_key'),
+        '#description' => 'Key for Shelve It session creation',
+      ];
 
     return parent::buildForm($form, $form_state);
   }
-
 }

--- a/src/Form/SummerGameAdminForm.php
+++ b/src/Form/SummerGameAdminForm.php
@@ -11,19 +11,22 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 
-class SummerGameAdminForm extends ConfigFormBase {
+class SummerGameAdminForm extends ConfigFormBase
+{
 
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId()
+  {
     return 'summergame_admin_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state)
+  {
     $config = $this->config('summergame.settings');
 
     foreach (Element::children($form) as $variable) {
@@ -41,11 +44,13 @@ class SummerGameAdminForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  protected function getEditableConfigNames() {
+  protected function getEditableConfigNames()
+  {
     return ['summergame.settings'];
   }
 
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state)
+  {
     $summergame_settings = \Drupal::config('summergame.settings');
     $form = [];
     $form['summergame_points_enabled'] = [
@@ -235,12 +240,19 @@ class SummerGameAdminForm extends ConfigFormBase {
       '#default_value' => $summergame_settings->get('summergame_homecode_report_threshold'),
       '#description' => 'Number of player reports needed to remove a Home Code from the map',
     ];
-    $form['summergame_shelveit_key'] =
+    $form['summergame_scatterlog_key'] =
       [
         '#type' => 'textfield',
-        '#title' => 'Shelve It App Key',
-        '#default_value' => $summergame_settings->get('summergame_shelveit_key'),
-        '#description' => 'Key for Shelve It session creation',
+        '#title' => 'Scatterlog App Key',
+        '#default_value' => $summergame_settings->get('summergame_scatterlog_key'),
+        '#description' => 'Key for Scatterlog session creation',
+      ];
+    $form['summergame_scatterlog_url'] =
+      [
+        '#type' => 'textfield',
+        '#title' => 'Scatterlog URL',
+        '#default_value' => $summergame_settings->get('summergame_scatterlog_url'),
+        '#description' => 'URL for scatter log',
       ];
 
     return parent::buildForm($form, $form_state);

--- a/src/Form/SummerGamePlayerForm.php
+++ b/src/Form/SummerGamePlayerForm.php
@@ -10,19 +10,22 @@ namespace Drupal\summergame\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 
-class SummerGamePlayerForm extends FormBase {
+class SummerGamePlayerForm extends FormBase
+{
 
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId()
+  {
     return 'summergame_player_form';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $pid = 0) {
+  public function buildForm(array $form, FormStateInterface $form_state, $pid = 0)
+  {
     $route = \Drupal::routeMatch()->getRouteName();
     $db = \Drupal::database();
     $summergame_settings = \Drupal::config('summergame.settings');
@@ -30,7 +33,7 @@ class SummerGamePlayerForm extends FormBase {
     $user = \Drupal::currentUser();
 
     $submit_text = 'Save Player Changes';
-    
+
     if ($route == 'summergame.player.new') {
       // Check if user logged in
       if ($uid = $user->id()) {
@@ -38,19 +41,16 @@ class SummerGamePlayerForm extends FormBase {
         if ($player = summergame_player_load(['uid' => $uid])) {
           \Drupal::messenger()->addMessage('Redirecting to your existing player');
           return $this->redirect('summergame.player', ['pid' => $player['pid']]);
-        } 
-        else {
+        } else {
           // Website user, no player, set up empty player record
           $player = ['uid' => $uid];
           $submit_text = 'Sign Up';
         }
-      } 
-      else {
+      } else {
         \Drupal::messenger()->addMessage('You need to log in to the website before you can sign up a player');
         return $this->redirect('<front>')->send();
       }
-    } 
-    else if ($route == 'summergame.player.extra') {
+    } else if ($route == 'summergame.player.extra') {
       // Check if user logged in
       if ($uid = $user->id()) {
         // Check if existing player
@@ -66,18 +66,15 @@ class SummerGamePlayerForm extends FormBase {
             "<b>Each player on your account must be a real person who lives in your home.</b>";
           \Drupal::messenger()->addMessage(['#markup' => $extra_player_message]);
           $player = ['uid' => $uid];
-        } 
-        else {
+        } else {
           // Website user, no player, redirect to new player form
           return $this->redirect('summergame.player.new')->send();
         }
-      } 
-      else {
+      } else {
         \Drupal::messenger()->addMessage('You need to log in to the website before you can sign up a player');
         return $this->redirect('summergame.player');
       }
-    } 
-    else {
+    } else {
       $player = summergame_player_load($pid);
     }
 
@@ -119,11 +116,9 @@ class SummerGamePlayerForm extends FormBase {
 
     if ($player['pid']) {
       $cancel_path = 'summergame/player/' . $player['pid'];
-    } 
-    else if (strpos($_GET['q'], 'admin') !== FALSE) {
+    } else if (strpos($_GET['q'], 'admin') !== FALSE) {
       $cancel_path = 'summergame/admin';
-    } 
-    else {
+    } else {
       $cancel_path = '';
     }
     if ($player['pid']) {
@@ -177,8 +172,7 @@ class SummerGamePlayerForm extends FormBase {
         '#maxlength' => 64,
         '#description' => t('Enter a phone number to play by text message (rates may apply)'),
       ];
-    } 
-    else if ($player['phone']) {
+    } else if ($player['phone']) {
       $form['phone'] = [
         '#type' => 'value',
         '#value' => $player['phone'],
@@ -240,8 +234,7 @@ class SummerGamePlayerForm extends FormBase {
     ];
     if ($player['agegroup'] == 'youth' || $player['agegroup'] == 'teen') {
       $school_style = 'display: block';
-    } 
-    else {
+    } else {
       $school_style = 'display: none';
     }
 
@@ -298,8 +291,7 @@ class SummerGamePlayerForm extends FormBase {
         '#maxlength' => 8,
         '#description' => t("Website User ID to connect this player") . $search_link,
       ];
-    } 
-    else if ($player['uid']) {
+    } else if ($player['uid']) {
       $form['uid'] = [
         '#type' => 'value',
         '#value' => $player['uid'],
@@ -314,21 +306,24 @@ class SummerGamePlayerForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
+  public function validateForm(array &$form, FormStateInterface $form_state)
+  {
   }
 
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state)
+  {
     $summergame_settings = \Drupal::config('summergame.settings');
     $gameDisplayName = $summergame_settings->get('game_display_name');
     // Check for merge ID
     if ($form_state->getValue('pid') && $form_state->getValue('merge_id')) {
-      $form_state->setRedirect('summergame.admin.players.merge', 
-      ['pid1' => $form_state->getValue('merge_id'), 'pid2' => $form_state->getValue('pid')]);
-    } 
-    else {
+      $form_state->setRedirect(
+        'summergame.admin.players.merge',
+        ['pid1' => $form_state->getValue('merge_id'), 'pid2' => $form_state->getValue('pid')]
+      );
+    } else {
       $player_info = [
         'name' => $form_state->getValue('name'),
         'nickname' => trim($form_state->getValue('nickname')),
@@ -344,8 +339,7 @@ class SummerGamePlayerForm extends FormBase {
         if (strlen($phone) == 7) {
           // preface with local area code
           $phone = '1734' . $phone;
-        } 
-        else if (strlen($phone) == 10) {
+        } else if (strlen($phone) == 10) {
           // preface with a 1
           $phone = '1' . $phone;
         }
@@ -367,8 +361,7 @@ class SummerGamePlayerForm extends FormBase {
         if ($form_state->getValue('signup_eligible') && $form_state->getValue('gamecard')) {
           $signup_bonus = TRUE;
         }
-      } 
-      else {
+      } else {
         $signup_bonus = TRUE;
       }
 
@@ -376,8 +369,12 @@ class SummerGamePlayerForm extends FormBase {
 
       if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
         if ($signup_bonus) {
-          $points = summergame_player_points($player['pid'], 100, 'Signup',
-                                             'Signed Up for the Summer Game');
+          $points = summergame_player_points(
+            $player['pid'],
+            100,
+            'Signup',
+            'Signed Up for the Summer Game'
+          );
           \Drupal::messenger()->addMessage("Earned $points Summer Game points for signing up!");
         }
         /*
@@ -405,11 +402,10 @@ class SummerGamePlayerForm extends FormBase {
         }
     */
       }
-      if ($_GET['shelveit'] == true) {
+      if ($_GET['scatterlog'] == true) {
         \Drupal::messenger()->deleteAll();
-        $form_state->setRedirect('summergame.shelveit.connect');
-      } 
-      else {
+        $form_state->setRedirect('summergame.scatterlog.connect');
+      } else {
         $form_state->setRedirect('summergame.player', ['pid' => $player['pid']]);
       }
     }

--- a/src/Form/SummerGamePlayerForm.php
+++ b/src/Form/SummerGamePlayerForm.php
@@ -30,7 +30,7 @@ class SummerGamePlayerForm extends FormBase {
     $user = \Drupal::currentUser();
 
     $submit_text = 'Save Player Changes';
-
+    
     if ($route == 'summergame.player.new') {
       // Check if user logged in
       if ($uid = $user->id()) {
@@ -38,18 +38,18 @@ class SummerGamePlayerForm extends FormBase {
         if ($player = summergame_player_load(['uid' => $uid])) {
           \Drupal::messenger()->addMessage('Redirecting to your existing player');
           return $this->redirect('summergame.player', ['pid' => $player['pid']]);
-        }
+        } 
         else {
           // Website user, no player, set up empty player record
           $player = ['uid' => $uid];
           $submit_text = 'Sign Up';
         }
-      }
+      } 
       else {
         \Drupal::messenger()->addMessage('You need to log in to the website before you can sign up a player');
         return $this->redirect('<front>')->send();
       }
-    }
+    } 
     else if ($route == 'summergame.player.extra') {
       // Check if user logged in
       if ($uid = $user->id()) {
@@ -57,26 +57,26 @@ class SummerGamePlayerForm extends FormBase {
         if (summergame_player_load(['uid' => $uid])) {
           // Website user, existing player, set up empty player record
           $extra_player_message = "Use the form below to add an extra player to your website account for another person in your household. " .
-                                  "You will be able to enter game codes and report reading / listening / " .
-                                  "watching activities for points. You will be able to switch the active player on your " .
-                                  "website account to specify which player receives points for online activities such as " .
-                                  "commenting, tagging, or writing reviews. If you wish this " .
-                                  "player to have a separate website identity for these online activites, please log " .
-                                  "out and create a new website account before signing up for the $gameDisplayName.<br><br>" .
-                                  "<b>Each player on your account must be a real person who lives in your home.</b>";
+            "You will be able to enter game codes and report reading / listening / " .
+            "watching activities for points. You will be able to switch the active player on your " .
+            "website account to specify which player receives points for online activities such as " .
+            "commenting, tagging, or writing reviews. If you wish this " .
+            "player to have a separate website identity for these online activites, please log " .
+            "out and create a new website account before signing up for the $gameDisplayName.<br><br>" .
+            "<b>Each player on your account must be a real person who lives in your home.</b>";
           \Drupal::messenger()->addMessage(['#markup' => $extra_player_message]);
           $player = ['uid' => $uid];
-        }
+        } 
         else {
           // Website user, no player, redirect to new player form
           return $this->redirect('summergame.player.new')->send();
         }
-      }
+      } 
       else {
         \Drupal::messenger()->addMessage('You need to log in to the website before you can sign up a player');
         return $this->redirect('summergame.player');
       }
-    }
+    } 
     else {
       $player = summergame_player_load($pid);
     }
@@ -90,7 +90,7 @@ class SummerGamePlayerForm extends FormBase {
       if (!$player['gamecard']) {
         $game_term = $summergame_settings->get('summergame_current_game_term');
         $signup = $db->query("SELECT * FROM sg_ledger WHERE pid = " . $player['pid'] .
-                             " AND type = 'Signup' AND game_term = '$game_term'")->fetchObject();
+          " AND type = 'Signup' AND game_term = '$game_term'")->fetchObject();
         if (!$signup->lid) {
           $form['signup_eligible'] = [
             '#type' => 'value',
@@ -100,9 +100,9 @@ class SummerGamePlayerForm extends FormBase {
       }
       $form['title'] = [
         '#value' => '<p style="float: right">' .
-                    '<a href="/summergame/player/' . $player['pid'] . '">Back to Player Score Card page</a>' .
-                    '</p>' .
-                    '<h1>Edit $gameDisplayName Player Information</h1>',
+          '<a href="/summergame/player/' . $player['pid'] . '">Back to Player Score Card page</a>' .
+          '</p>' .
+          '<h1>Edit $gameDisplayName Player Information</h1>',
       ];
     }
 
@@ -119,18 +119,18 @@ class SummerGamePlayerForm extends FormBase {
 
     if ($player['pid']) {
       $cancel_path = 'summergame/player/' . $player['pid'];
-    }
+    } 
     else if (strpos($_GET['q'], 'admin') !== FALSE) {
       $cancel_path = 'summergame/admin';
-    }
+    } 
     else {
       $cancel_path = '';
     }
     if ($player['pid']) {
       $form['buttons']['links'] = [
         '#markup' => '<a href="/' . $cancel_path . '">Cancel</a>' .
-                     '&nbsp;&nbsp;&nbsp;&nbsp;' .
-                     '<a href="/summergame/player/' . $player['pid'] . '/delete">Delete Player</a>',
+          '&nbsp;&nbsp;&nbsp;&nbsp;' .
+          '<a href="/summergame/player/' . $player['pid'] . '/delete">Delete Player</a>',
       ];
     }
 
@@ -177,7 +177,7 @@ class SummerGamePlayerForm extends FormBase {
         '#maxlength' => 64,
         '#description' => t('Enter a phone number to play by text message (rates may apply)'),
       ];
-    }
+    } 
     else if ($player['phone']) {
       $form['phone'] = [
         '#type' => 'value',
@@ -240,7 +240,7 @@ class SummerGamePlayerForm extends FormBase {
     ];
     if ($player['agegroup'] == 'youth' || $player['agegroup'] == 'teen') {
       $school_style = 'display: block';
-    }
+    } 
     else {
       $school_style = 'display: none';
     }
@@ -298,7 +298,7 @@ class SummerGamePlayerForm extends FormBase {
         '#maxlength' => 8,
         '#description' => t("Website User ID to connect this player") . $search_link,
       ];
-    }
+    } 
     else if ($player['uid']) {
       $form['uid'] = [
         '#type' => 'value',
@@ -323,11 +323,11 @@ class SummerGamePlayerForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $summergame_settings = \Drupal::config('summergame.settings');
     $gameDisplayName = $summergame_settings->get('game_display_name');
-  // Check for merge ID
+    // Check for merge ID
     if ($form_state->getValue('pid') && $form_state->getValue('merge_id')) {
-      $form_state->setRedirect('summergame.admin.players.merge',
-                              ['pid1' => $form_state->getValue('merge_id'), 'pid2' => $form_state->getValue('pid')]);
-    }
+      $form_state->setRedirect('summergame.admin.players.merge', 
+      ['pid1' => $form_state->getValue('merge_id'), 'pid2' => $form_state->getValue('pid')]);
+    } 
     else {
       $player_info = [
         'name' => $form_state->getValue('name'),
@@ -344,7 +344,7 @@ class SummerGamePlayerForm extends FormBase {
         if (strlen($phone) == 7) {
           // preface with local area code
           $phone = '1734' . $phone;
-        }
+        } 
         else if (strlen($phone) == 10) {
           // preface with a 1
           $phone = '1' . $phone;
@@ -367,7 +367,7 @@ class SummerGamePlayerForm extends FormBase {
         if ($form_state->getValue('signup_eligible') && $form_state->getValue('gamecard')) {
           $signup_bonus = TRUE;
         }
-      }
+      } 
       else {
         $signup_bonus = TRUE;
       }
@@ -380,7 +380,7 @@ class SummerGamePlayerForm extends FormBase {
                                              'Signed Up for the Summer Game');
           \Drupal::messenger()->addMessage("Earned $points Summer Game points for signing up!");
         }
-    /*
+        /*
         // Check for referral bonus
         if ($form_state->getValue('referred_by']) {
           // Check for referral player
@@ -405,8 +405,13 @@ class SummerGamePlayerForm extends FormBase {
         }
     */
       }
-
-      $form_state->setRedirect('summergame.player', ['pid' => $player['pid']]);
+      if ($_GET['shelveit'] == true) {
+        \Drupal::messenger()->deleteAll();
+        $form_state->setRedirect('summergame.shelveit.connect');
+      } 
+      else {
+        $form_state->setRedirect('summergame.player', ['pid' => $player['pid']]);
+      }
     }
     return;
   }

--- a/summergame.module
+++ b/summergame.module
@@ -248,6 +248,12 @@ function summergame_theme() {
         'leaderboard_timestamp' => NULL,
         'leaderboard' => NULL,
       ]
+    ],
+    'summergame_player_external_redeem' => [
+      'variables' => [
+        'players' => NULL,
+        'uid' => NULL,
+      ]
     ]
   ];
 }

--- a/summergame.routing.yml
+++ b/summergame.routing.yml
@@ -323,7 +323,7 @@ summergame.shelveit.connect:
   requirements:
     _permission: 'access summergame'
 summergame.shelveit.connect_process:
-  path: '/summergame/shelveit/connect/{pid}'
+  path: '/summergame/shelveit/connect/{uid}'
   defaults:
     _controller: '\Drupal\summergame\Controller\ConnectionController:connect'
     _title: 'Summer Game Account Connection'

--- a/summergame.routing.yml
+++ b/summergame.routing.yml
@@ -315,3 +315,17 @@ summergame.trivia.update:
     _title: 'Summer Game Trivia Update'
   requirements:
     _permission: 'access summergame'
+summergame.shelveit.connect:
+  path: '/summergame/shelveit/connect'
+  defaults:
+    _controller: '\Drupal\summergame\Controller\ConnectionController:show'
+    _title: 'Summer Game Account Connection'
+  requirements:
+    _permission: 'access summergame'
+summergame.shelveit.connect_process:
+  path: '/summergame/shelveit/connect/{pid}'
+  defaults:
+    _controller: '\Drupal\summergame\Controller\ConnectionController:connect'
+    _title: 'Summer Game Account Connection'
+  requirements:
+    _permission: 'access summergame'

--- a/summergame.routing.yml
+++ b/summergame.routing.yml
@@ -315,15 +315,15 @@ summergame.trivia.update:
     _title: 'Summer Game Trivia Update'
   requirements:
     _permission: 'access summergame'
-summergame.shelveit.connect:
-  path: '/summergame/shelveit/connect'
+summergame.scatterlog.connect:
+  path: '/summergame/scatterlog/connect'
   defaults:
     _controller: '\Drupal\summergame\Controller\ConnectionController:show'
     _title: 'Summer Game Account Connection'
   requirements:
     _permission: 'access summergame'
-summergame.shelveit.connect_process:
-  path: '/summergame/shelveit/connect/{uid}'
+summergame.scatterlog.connect_process:
+  path: '/summergame/scatterlog/connect/{uid}'
   defaults:
     _controller: '\Drupal\summergame\Controller\ConnectionController:connect'
     _title: 'Summer Game Account Connection'

--- a/templates/summergame-player-external-redeem.html.twig
+++ b/templates/summergame-player-external-redeem.html.twig
@@ -1,8 +1,8 @@
 <div id="summergame-admin-page">
-  <h1>Connect Shelve It to player account</h1>
+  <h1>Connect Scatterlog to player account</h1>
   <p>Earn Summer Game points as you complete the daily puzzle by connecting your player accounts. You may switch between accounts in the game.</p>
  {% if players|length > 0 %}
- <a class="button" href="/summergame/shelveit/connect/{{uid}}">Connect</a>
+ <a class="button" href="/summergame/scatterlog/connect/{{uid}}">Connect</a>
   <table class="not-fixed-table smaller-font">
 	<thead>
 		<th>Player Accounts</th>
@@ -17,13 +17,13 @@
   </table>
   <div>
   <p>Need to create another player account for a household library account?</p>
-   <a class="button" href="/summergame/player/extra?shelveit=true">New Player</a>
+   <a class="button" href="/summergame/player/extra?scatterlog=true">New Player</a>
   </div>
   {% else %}
   <div>
 	<h2>No player accounts found.</h2>
-	 <p>Create a player account to earn points from completing Shelve it puzzles</p>
-	 <a class="button" href="/summergame/player/new?shelveit=true">New Player</a>
+	 <p>Create a player account to earn points from completing Scatterlog puzzles</p>
+	 <a class="button" href="/summergame/player/new?scatterlog=true">New Player</a>
 	</div>
   {% endif %}
 </div>

--- a/templates/summergame-player-external-redeem.html.twig
+++ b/templates/summergame-player-external-redeem.html.twig
@@ -1,17 +1,16 @@
 <div id="summergame-admin-page">
   <h1>Connect Shelve It to player account</h1>
-  <p>Earn Summer Game points as you complete the daily puzzle by connecting your player account</p>
+  <p>Earn Summer Game points as you complete the daily puzzle by connecting your player accounts. You may switch between accounts in the game.</p>
  {% if players|length > 0 %}
+ <a class="button" href="/summergame/shelveit/connect/{{uid}}">Connect</a>
   <table class="not-fixed-table smaller-font">
 	<thead>
-		<th>Player Account</th>
-		<th></th>
+		<th>Player Accounts</th>
 	</thead>
 	<tbody>
 	 {% for player in players %}
 		<tr>
-			<td><h2>{{player.nickname}}<h2></td>
-			<td><strong><a href="/summergame/shelveit/connect/{{player.pid}}">Connect</a><strong></td>
+			<td>{{player.nickname ? player.nickname : player.name}}</td>
 		</tr>
 	{% endfor %}
 	</tbody>

--- a/templates/summergame-player-external-redeem.html.twig
+++ b/templates/summergame-player-external-redeem.html.twig
@@ -1,0 +1,30 @@
+<div id="summergame-admin-page">
+  <h1>Connect Shelve It to player account</h1>
+  <p>Earn Summer Game points as you complete the daily puzzle by connecting your player account</p>
+ {% if players|length > 0 %}
+  <table class="not-fixed-table smaller-font">
+	<thead>
+		<th>Player Account</th>
+		<th></th>
+	</thead>
+	<tbody>
+	 {% for player in players %}
+		<tr>
+			<td><h2>{{player.nickname}}<h2></td>
+			<td><strong><a href="/summergame/shelveit/connect/{{player.pid}}">Connect</a><strong></td>
+		</tr>
+	{% endfor %}
+	</tbody>
+  </table>
+  <div>
+  <p>Need to create another player account for a household library account?</p>
+   <a class="button" href="/summergame/player/extra?shelveit=true">New Player</a>
+  </div>
+  {% else %}
+  <div>
+	<h2>No player accounts found.</h2>
+	 <p>Create a player account to earn points from completing Shelve it puzzles</p>
+	 <a class="button" href="/summergame/player/new?shelveit=true">New Player</a>
+	</div>
+  {% endif %}
+</div>


### PR DESCRIPTION
Connects AADL accounts via UID to Scatterlog. 

- Relies on key and URL in summer game admin form
- Users with no players are prompted to create a new player and can be automatically redirected to the connect screen after creation via a URL param
- Player swapping supported in the game itself. Only supports 10 player accounts at the moment.
- Milestone badges will also be handled in the game code. Will need to confirm with ejk and marketing how/if the badge visual should show up.

I'd like to get this on production well before June 14 just to do some reality checks on the connections. It's fairly straightforward though, and the testing on the dev site seemed to work fine. Future changes will happen on the game side.