### PR TITLE
fix partial string code matches from redirecting to badge

### DIFF
--- a/summergame.module
+++ b/summergame.module
@@ -1083,7 +1083,7 @@ function summergame_redeem_code($player, $code_text) {
     }
 
     // Add Badge title to description if code is part of a formula
-    $res = $db->query("SELECT gt.entity_id AS bid, n.title AS title " .
+    $res = $db->query("SELECT gt.entity_id AS bid, n.title AS title, f.field_badge_formula_value as formula" .
                       "FROM node_field_data n, node__field_badge_game_term gt, node__field_badge_formula f " .
                       "WHERE n.nid = gt.entity_id " .
                       "AND gt.entity_id = f.entity_id " .
@@ -1092,7 +1092,7 @@ function summergame_redeem_code($player, $code_text) {
                       "AND f.field_badge_formula_value LIKE :code_text " .
                       "ORDER BY bid DESC LIMIT 1",
                       [':game_term' => $code->game_term, ':code_text' => "%$code->text%"])->fetchObject();
-    if (isset($res->bid)) {
+    if (isset($res->bid) && strpos(strtolower($res->forumla), strtolower($code->text)) !== FALSE) {
       $code->description .= " [Part of the $res->title badge.]";
       $result['bid'] = $res->bid;
     }

--- a/summergame.module
+++ b/summergame.module
@@ -1092,9 +1092,13 @@ function summergame_redeem_code($player, $code_text) {
                       "AND f.field_badge_formula_value LIKE :code_text " .
                       "ORDER BY bid DESC LIMIT 1",
                       [':game_term' => $code->game_term, ':code_text' => "%$code->text%"])->fetchObject();
-    if (isset($res->bid) && strpos(strtolower($res->forumla), strtolower($code->text)) !== FALSE) {
-      $code->description .= " [Part of the $res->title badge.]";
-      $result['bid'] = $res->bid;
+    if (isset($res->bid)) {
+      $badge_formula = strtolower($res->formula);
+      $badge_formula_split = preg_split('/[,|]/', $badge_formula);
+      if (in_array(strtolower($code->text), $badge_formula_split)) {
+        $code->description .= " [Part of the $res->title badge.]";
+        $result['bid'] = $res->bid;
+      }
     }
 
     // Add sequence number to description


### PR DESCRIPTION
Prevents partial strings in codes from matching with badge formulas and redirecting in case of similarities in lawn/library codes or possibly other SG codes.