### PR TITLE
Add a check for the active player existing

### DIFF
--- a/summergame.module
+++ b/summergame.module
@@ -1254,7 +1254,7 @@ function summergame_get_active_player() {
       }
 
       $active_player = summergame_player_load($active_player['pid']);
-      if (count($user_players)) {
+      if (count($user_players) && $active_player) {
         $active_player['other_players'] = $user_players;
       }
     }


### PR DESCRIPTION
Add a check for the active player existing before assigning other_players.  

I haven't dug into why the user_data table  can sometimes have an active player that doesn't exist.  In this case, I think that's what's the active player to be false when loaded via summergame_get_active_player
