### PR TITLE
Break apart scorecards by game term.  each score card lives at its ow…

### DIFF
--- a/summergame.module
+++ b/summergame.module
@@ -443,6 +443,7 @@ function summergame_theme() {
         'other_players' => NULL,
         'quick_transfer' => NULL,
         'points' => NULL,
+        'game_terms_played' => NULL,
         'balances' => NULL,
         'pointsomatic_weekly_totals' => NULL,
         'progress' => NULL,
@@ -456,6 +457,15 @@ function summergame_theme() {
         'homecode' => NULL,
         'game_display_name' => NULL,
         'summergame_leagues_enabled' => NULL,
+      ],
+    ],
+    'summergame_player_scorecard' => [
+      'variables' => [
+        'points' => NULL,
+        'game_term_valid' => FALSE,
+        'page_game_term' => NULL,
+        'player' => NULL,
+        'directory'=>'themes/custom/aadl',
       ],
     ],
     'summergame_player_ledger' => [
@@ -1276,13 +1286,15 @@ function summergame_get_active_player() {
  */
 function summergame_get_player_points($pid, $game_term = '', $type = '') {
   $term_filter = FALSE;
+
   $player_points = [
     'career' => 0,
   ];
 
+
   $query = 'SELECT * FROM sg_ledger WHERE pid = :pid';
   $args = [':pid' => $pid];
-  if ($game_term) {
+  if ($game_term != '') {
     $query .= " AND game_term = :game_term";
     $args[':game_term'] = $game_term;
     $term_filter = TRUE;
@@ -1293,17 +1305,16 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   }
   $query .= ' ORDER BY timestamp DESC';
 
+
   $db = \Drupal::database();
   $res = $db->query($query, $args);
 
   while ($row = $res->fetchAssoc()) {
-    $game_term = $row['game_term'];
-    $type = $row['type'];
-
-    // Only include ledger rows if filtered to a game term
-    if ($term_filter) {
-      $player_points[$game_term]['ledger'][] = $row;
+    if (!$term_filter) {
+      $game_term = $row['game_term'];
     }
+    
+    $type = $row['type'];
 
     // if game term is not set, initialize point values
     if (!isset($player_points[$game_term])) {
@@ -1311,8 +1322,8 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
         'balance' => 0,
         'total' => 0,
         'prize_count' => 0,
-        'max_timestamp' => $row['timestamp'],
-        'min_timestamp' => $row['timestamp'],
+        'max_timestamp' => (int)$row['timestamp'],
+        'min_timestamp' => (int)$row['timestamp'],
       ];
     }
     else {
@@ -1321,6 +1332,11 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
       if ($row['timestamp'] < $player_points[$game_term]['min_timestamp']) {
         $player_points[$game_term]['min_timestamp'] = $row['timestamp'];
       }
+    }
+
+    // Only include ledger rows if filtered to a game term
+    if ($term_filter) {
+      $player_points[$game_term]['ledger'][] = $row;
     }
 
     // if type for this game term is not set, initialize point value
@@ -1351,9 +1367,19 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   }
 
   // Get old badges
+  $params = [':pid' => $pid];
+  $game_term_filter = "";
+  $new_game_term_filter = "";
+  if ($game_term !== "") {
+    $game_term_filter = " AND sg_badges.game_term = :game_term ";
+    $new_game_term_filter = " AND gt.field_badge_game_term_value = :game_term ";
+
+    $params[':game_term'] = $game_term;
+  }
+
   $res = $db->query("SELECT * FROM sg_players_badges, sg_badges " .
-                    "WHERE sg_players_badges.pid = :pid AND sg_players_badges.bid = sg_badges.bid " .
-                    "ORDER BY sg_players_badges.timestamp ASC", [':pid' => $pid]);
+                    "WHERE sg_players_badges.pid = :pid AND sg_players_badges.bid = sg_badges.bid " . $game_term_filter .
+                    "ORDER BY sg_players_badges.timestamp ASC", $params);
   while ($badge = $res->fetchAssoc()) {
     $game_term = $badge['game_term'];
     $badge['img'] = '/files/old-sg-images/' . $badge['image'] . '_100.png';
@@ -1368,8 +1394,8 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   $res = $db->query("SELECT gt.entity_id AS bid, gt.field_badge_game_term_value AS game_term, b.bid AS pbid " .
                     "FROM node__field_badge_game_term gt, sg_players_badges b " .
                     "WHERE gt.entity_id = b.bid " .
-                    "AND b.pid = :pid " .
-                    "ORDER BY bid ASC", [':pid' => $pid]);
+                    "AND b.pid = :pid " . $new_game_term_filter .
+                    "ORDER BY bid ASC", $params);
   while ($badge = $res->fetchAssoc()) {
     $game_term = $badge['game_term'];
     $badge['nid'] = $badge['bid'];
@@ -1393,6 +1419,19 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   }
 
   return $player_points;
+}
+
+
+function summergame_get_player_game_terms($pid){
+  $query = 'SELECT DISTINCT game_term FROM sg_ledger WHERE pid = :pid AND points <> 0 ORDER BY game_term DESC';
+  $args = [':pid' => (int)$pid];
+  $db = \Drupal::database();
+  $res = $db->query($query, $args);
+  $arr = [];
+  while ($row = $res->fetchAssoc()) {
+    $arr[] = $row['game_term'];
+  }
+  return $arr;
 }
 
 /**

--- a/summergame.routing.yml
+++ b/summergame.routing.yml
@@ -129,6 +129,14 @@ summergame.player:
     pid: 0
   requirements:
     _permission: 'access content'
+summergame.player.scorecard:
+  path: '/summergame/scorecard/{pid}/{game_term}'
+  defaults:
+    _controller: '\Drupal\summergame\Controller\PlayerController::get_game_term_scorecard'
+    _title: 'Summer Game Player Scorecard'
+    pid: 0
+  requirements:
+    _permission: 'access content'
 summergame.player.new:
   path: '/summergame/player/new'
   defaults:

--- a/templates/summergame-player-info.html.twig
+++ b/templates/summergame-player-info.html.twig
@@ -29,6 +29,9 @@
           {% endif %}
         {% endfor %}
       </table>
+      <br>
+      <br>
+      <a href="#scorecards">See previous game scorecards</a>
       {% if balances|length %}
         <h2>Shop Balances</h2>
         <table class="account-summary not-fixed-table">

--- a/templates/summergame-player-scorecard.html.twig
+++ b/templates/summergame-player-scorecard.html.twig
@@ -3,30 +3,15 @@
  * Summer Game Player Page
  */
 #}
-
-<h1 class="t-center ruled-heading large-heading"><span>My Game Players</span></h1>
+{% if game_term_valid %}
+<h1 class="t-center ruled-heading large-heading"><span>{{ page_game_term }} Scorecard</span></h1>
 <div class="sidebar-container">
   <div class="page-with-sidebar-content">
-    <div id="summergame-player-page">
-      {% if player_access %}
-        {% include('@summergame/summergame-player-info.html.twig') %}
-      {% endif %}
-      {# Player Score #}
+{% for game_term, player_game_points in points %}
 
-      {% for game_term, player_game_points in points %}
+  {% if game_term == page_game_term %}
         {% if player_game_points.total or player_game_points.balance %}
           <div class="scorecard">
-            {% if loop.index0 != 1 %}
-              <div class="facets-toggle">
-                <span class="facets-toggle-icon">
-                  <span class="facets-toggle-symbol">+</span>
-                </span>
-                <h2 id="{{ game_term }}" class="l-inline-b no-margin-bottom">{{ game_term }} Scorecard</h2>
-              </div>
-            {% else %}
-              <h2 id="{{ game_term }}" class="l-inline-b no-margin-bottom">{{ game_term }} Scorecard</h2>
-            {% endif %}
-            <div {% if loop.index0 != 1 %} class="no-display" {% endif %}>
               <div class="player-points">
                 <h3 class="no-margin-bottom">Points</h3>
                 <table>
@@ -41,10 +26,6 @@
                     <tr><td>Current Points Balance</td><td>{{ player_game_points.balance }}</td></tr>
                   {% endif %}
                 </table>
-
-                <div class="scorecard-buttons">
-                    <a class="button" href="/summergame/player/{{ player.pid }}/ledger?term={{ game_term }}">See Full Scorecard</a>
-                </div>
 
                 <p>Points date range: <br>
                 {{ player_game_points.min_timestamp|date('F j, Y, g:i a') }} -<br>
@@ -70,19 +51,15 @@
                   {% endif %}
                 </div>
               {% endif %}
-            </div>
+     
           </div> <!-- .scorecard -->
         {% endif %}
+        {% endif %}
       {% endfor %}
-
-      <br><br>
-      <div id="scorecards">
-      {% for game_term in game_terms_played %}
-        <h2><a href="/summergame/scorecard/{{ player.pid }}/{{ game_term }}" target="_blank">{{ game_term }} Scorecard</a></h2>
-      {% endfor %}
-      </div>
-
-    </div>
   </div>
   {% include directory ~ "/templates/base/nodes/sidebars/summergame.html.twig" %}
 </div>
+{% endif %}
+{% if not game_term_valid %}
+<p>You don't have any points in this game term</p>
+{% endif %}


### PR DESCRIPTION
Break apart scorecards by game term. 
 - Each score card lives at its own url. 
 - The player page now only displays totals for the current game term. 
 - Dropdowns for past game terms are now links to the individual scorecards.  
 - Rework points totaling function to fully support game_term filtering