### PR TITLE
add page that lists all players and their points for a given user

### DIFF
--- a/summergame.routing.yml
+++ b/summergame.routing.yml
@@ -414,3 +414,10 @@ summergame.aaps.code:
     line_number_hash: null
   requirements:
     _permission: 'access content'
+summergame.all.player.summary:
+  path: '/summergame/user/{uid}/all-players'
+  defaults:
+    _controller: '\Drupal\summergame\Controller\PlayerController::all_player_summary'
+    _title: 'Summer Game All Player Summary'
+  requirements:
+    _permission: 'access summergame'

--- a/templates/sg-all-player-summary.html.twig
+++ b/templates/sg-all-player-summary.html.twig
@@ -1,0 +1,25 @@
+<article>
+  <h1 class="no-margin">All Players Summary</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Player ID</th>
+        <th>Player Name</th>
+        <th>Player Nickname</th>
+        <th>Total Career Points</th>
+        <th>Total Shop Points</th>
+      </tr>
+    </thead>
+      {% for player in players %}
+        
+      <tr>
+        <td><a href="/summergame/player/{{ player.pid }}">{{ player.pid }}</a></td>
+        <td>{{ player.name }}</td>
+        <td>{{ player.nickname }}</td>
+        <td>{{ player.player_points.career }}</td>
+        <td>{{ player.commerce_points.SummerGame }}</td>
+      </tr>
+        
+      {% endfor %}
+  </table>     
+</article>


### PR DESCRIPTION
@taleon I've setup the page for the Game Over Gala Auction.  Wasn't sure which info was needed on the page overall, so I included  Player ID,  Player Name, Player Nickname, Total Career Points, Total Shop Points.

Player ID links back to the player page as well