### PR TITLE
Cache point totals to redis

### DIFF
--- a/summergame.module
+++ b/summergame.module
@@ -1365,7 +1365,8 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   }
   
   if (!is_null($redis)) {
-    $cached_points_raw = $redis->get("summergame:points:$pid");
+    $host = \Drupal::request()->getHost();
+    $cached_points_raw = $redis->get("$host:summergame:points:$pid");
     if (!is_null($cached_points_raw)) {
       $cached_points = json_decode($cached_points_raw, true);
       if($cached_points['timestamp'] > strtotime('-1 hour',time())){
@@ -1384,7 +1385,7 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
           }
         }
       } else {
-        $redis->del("summergame:points:$pid");
+        $redis->del("$host:summergame:points:$pid");
       }
     }
   }
@@ -1544,7 +1545,7 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
     $points_cache_obj = [];
     $points_cache_obj['timestamp'] = time(); 
     $points_cache_obj['player_points'] = $player_points;
-    $redis->setEx("summergame:points:$pid", 3600, json_encode($points_cache_obj));
+    $redis->setEx("$host:summergame:points:$pid", 3600, json_encode($points_cache_obj));
   }
 
   return $player_points;

--- a/summergame.module
+++ b/summergame.module
@@ -40,6 +40,8 @@ function summergame_is_byteclub_page() {
 }
 
 function summergame_preprocess_html(&$variables) {
+
+
   if (summergame_is_byteclub_page()) {
     $variables['attributes']['class'][] = 'byte-club-skin';
     $module_path = \Drupal::service('module_handler')->getModule('summergame')->getpath();
@@ -1351,9 +1353,36 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   ];
 
 
-  $query = "SELECT SUM(points) AS total, MIN(timestamp) as min_timestamp,  MAX(timestamp) as max_timestamp, game_term, type, (CASE WHEN metadata LIKE '%leaderboard:no%' THEN 'leaderboard:no' WHEN metadata NOT LIKE '%leaderboard:no%' THEN '' END) as leader from sg_ledger WHERE pid = :pid";
+  //redis setup
+  $after = 0;
+  $using_cache = false;
+  $redis = new Client(\Drupal::config('summergame.settings')->get('summergame_redis_conn'));
+  $cached_points_raw = $redis->get("summergame:points:$pid");
+  if (!is_null($cached_points_raw)) {
+    $cached_points = json_decode($cached_points_raw, true);
+    if($cached_points['timestamp'] > strtotime('-1 hour',time())){
+      // lets use the cache
+      $using_cache = true;
+      $after = $cached_points['timestamp'];
+      $player_points = $cached_points['player_points'];
+      //deload badges and grab them fresh
+      foreach ($player_points as $badge_game_term => $data) {
+        if (isset($player_points[$badge_game_term]['badges'])) {
+          $player_points[$badge_game_term]['badges'] = [];
+        }
+        //unset game terms we don't want here.
+        if ($game_term !== '' && $badge_game_term !== $game_term && $badge_game_term !== 'career') {
+          unset($player_points[$badge_game_term]);
+        }
+      }
+    } else {
+      $redis->del("summergame:points:$pid");
+    }
+  }
 
-  $args = [':pid' => $pid];
+  $query = "SELECT SUM(points) AS total, MIN(timestamp) as min_timestamp,  MAX(timestamp) as max_timestamp, game_term, type, (CASE WHEN metadata LIKE '%leaderboard:no%' THEN 'leaderboard:no' WHEN metadata NOT LIKE '%leaderboard:no%' THEN '' END) as leader from sg_ledger WHERE pid = :pid AND timestamp > :after";
+
+  $args = [':pid' => $pid, ':after' => $after];
   if ($game_term != '') {
     $query .= " AND game_term = :game_term";
     $args[':game_term'] = $game_term;
@@ -1416,10 +1445,13 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   //$regexp = 'prize_count:(-?[0-9]+)';
   $query = $db->select('sg_ledger', 'sg_ledger')
   ->condition('pid', $pid, '=');
+  $query = $query->condition('timestamp', $after, '>');
   if ($term_filter) {
     $query = $query->condition('game_term', $game_term, '=');
   }
   $query = $query->condition('metadata', 'delete:no leaderboard:no prize_count:%', 'LIKE');
+  
+
   $query->fields('sg_ledger', ['metadata', 'game_term']);
 
   $result = $query->execute();
@@ -1496,6 +1528,14 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
     }
     $badge['title'] = $node->get('title')->value;
     $player_points[$game_term]['badges'][] = $badge;
+  }
+
+  //save in redis if we're not loading from it to ensure we sometimes still load from points from scratch.  also only save if there is no term filter. regardless of whether we loaded with the cache.
+  if (!$using_cache && $term_filter == FALSE) {
+    $points_cache_obj = [];
+    $points_cache_obj['timestamp'] = time(); 
+    $points_cache_obj['player_points'] = $player_points;
+    $redis->setEx("summergame:points:$pid", 3600, json_encode($points_cache_obj));
   }
 
 

--- a/summergame.module
+++ b/summergame.module
@@ -1352,31 +1352,40 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
     'career' => 0,
   ];
 
-
   //redis setup
   $after = 0;
   $using_cache = false;
-  $redis = new Client(\Drupal::config('summergame.settings')->get('summergame_redis_conn'));
-  $cached_points_raw = $redis->get("summergame:points:$pid");
-  if (!is_null($cached_points_raw)) {
-    $cached_points = json_decode($cached_points_raw, true);
-    if($cached_points['timestamp'] > strtotime('-1 hour',time())){
-      // lets use the cache
-      $using_cache = true;
-      $after = $cached_points['timestamp'];
-      $player_points = $cached_points['player_points'];
-      //deload badges and grab them fresh
-      foreach ($player_points as $badge_game_term => $data) {
-        if (isset($player_points[$badge_game_term]['badges'])) {
-          $player_points[$badge_game_term]['badges'] = [];
+  $redis = null;
+  $cached_points_raw = null;
+  try{
+    $redis = new Client(\Drupal::config('summergame.settings')->get('summergame_redis_conn'));
+    $redis->connect();
+  } catch (Predis\Connection\ConnectionException $e) {
+    $redis = null;
+  }
+  
+  if (!is_null($redis)) {
+    $cached_points_raw = $redis->get("summergame:points:$pid");
+    if (!is_null($cached_points_raw)) {
+      $cached_points = json_decode($cached_points_raw, true);
+      if($cached_points['timestamp'] > strtotime('-1 hour',time())){
+        // lets use the cache
+        $using_cache = true;
+        $after = $cached_points['timestamp'];
+        $player_points = $cached_points['player_points'];
+        //deload badges and grab them fresh, deload game terms if filtering
+        foreach ($player_points as $badge_game_term => $data) {
+          if (isset($player_points[$badge_game_term]['badges'])) {
+            $player_points[$badge_game_term]['badges'] = [];
+          }
+          //unset game terms we don't want here.
+          if ($game_term !== '' && $badge_game_term !== $game_term && $badge_game_term !== 'career') {
+            unset($player_points[$badge_game_term]);
+          }
         }
-        //unset game terms we don't want here.
-        if ($game_term !== '' && $badge_game_term !== $game_term && $badge_game_term !== 'career') {
-          unset($player_points[$badge_game_term]);
-        }
+      } else {
+        $redis->del("summergame:points:$pid");
       }
-    } else {
-      $redis->del("summergame:points:$pid");
     }
   }
 
@@ -1531,13 +1540,12 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   }
 
   //save in redis if we're not loading from it to ensure we sometimes still load from points from scratch.  also only save if there is no term filter. regardless of whether we loaded with the cache.
-  if (!$using_cache && $term_filter == FALSE) {
+  if (!$using_cache && $term_filter == FALSE && !is_null($redis)) {
     $points_cache_obj = [];
     $points_cache_obj['timestamp'] = time(); 
     $points_cache_obj['player_points'] = $player_points;
     $redis->setEx("summergame:points:$pid", 3600, json_encode($points_cache_obj));
   }
-
 
   return $player_points;
 }


### PR DESCRIPTION
This caches point totals in Redis with a timestamp for when they were calculated.  points totaling will use the cached points and the timestamp to load in everything since that timestamp and add the new entries to get the current total.  Totals are only cached if the last cache entry has expired so it will update from scratch after the entry expires.  Alternatively we could make it update the cache each time totaling is run, I'm interested in what y'all think.

Currently I've got the ttl on these Redis entries set at 1 hour out of an abundance of caution, but maybe it should be way longer, like 1 or 2 days?