### PR TITLE
set uid to current user and redirect back with current uid 

### DIFF
--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -740,9 +740,12 @@ class PlayerController extends ControllerBase {
 
   public function all_player_summary($uid = 0){
     $user = \Drupal::currentUser();
-
     if ((int)$user->id() !== (int)$uid && !\Drupal::service('permission_checker')->hasPermission('manage summergame', $user)) {
         return new RedirectResponse('/user/login?destination=/summergame/player');
+    }
+    if ($uid == 0) {
+      $uid = (int)$user->id();
+      return new RedirectResponse("/summergame/user/$uid/all-players");
     }
     $players = summergame_player_load_all($uid);
     foreach ($players as $key => $player) {


### PR DESCRIPTION
on all players summary page - if uid is zero and access is verified, then set uid to current user and redirect back with current uid - similar to the default player page

This is to ensure we can use a generic QR code to link patrons to this page during an event.