### PR TITLE
Restyling two adjacent buttons on the player page

### DIFF
--- a/templates/summergame-player-info.html.twig
+++ b/templates/summergame-player-info.html.twig
@@ -11,9 +11,9 @@
   <div id="player-earn-links">
     <h2>Earn Game Points</h2>
     <div class="no-padding-left">
-      <a class="button" href="/summergame/player/{{ player.pid }}/gamecode">I have a Game Code!</a>
+      <a class="button base-margin-small-bottom" style="margin-right: 1.5em;" href="/summergame/player/{{ player.pid }}/gamecode">I have a Game Code!</a>
       {% if summergame_points_enabled %}
-        <a class="button base-margin-left" href="/summergame/player/{{ player.pid }}/consume">I Read, Listened to, or Watched something!</a>
+        <a class="button" href="/summergame/player/{{ player.pid }}/consume">I Read, Listened to, or Watched something!</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Previously, on narrow screen widths, the "I Read, Listened to, or Watched something!" button wasn't aligned to the left and also jutted up against the button above it.

This change results in the buttons being better aligned + also adds 0.375em of vertical space between, while preserving the 1.5em margin between the buttons when they do sit next to each other horizontally on wider screen widths

--
Fixes #142