### PR TITLE
Accessibility Fixes 2026

### DIFF
--- a/src/Controller/PlayerController.php
+++ b/src/Controller/PlayerController.php
@@ -537,7 +537,7 @@ class PlayerController extends ControllerBase {
         // Change bnum: code to a link to the bib record
         if (preg_match('/bnum:([\w-]+)/', $row['metadata'], $matches)) {
           if (preg_match('/^\d{7}$/', $matches[1])) {
-            $row['description'] = '<img src="//cdn.aadl.com/covers/' . $matches[1] . '_100.jpg" width="50"> ' . $row['description'];
+            $row['description'] = '<img src="//cdn.aadl.com/covers/' . $matches[1] . '_100.jpg" width="50" alt="Item Cover Image"> ' . $row['description'];
           }
           if ($row['type'] != 'Download of the Day' || $player_access) { // Don't link to DotD records
             $row['description'] = '<a href="/catalog/record/' . $matches[1] .  '">' .$row['description'] . '</a>';

--- a/src/Helper/BadgeRenderer.php
+++ b/src/Helper/BadgeRenderer.php
@@ -172,8 +172,8 @@ class BadgeRenderer {
               foreach ($bids as $bid) {
                 $node = \Drupal\node\Entity\Node::load($bid);
                 $faded_class = (isset($player['bids'][$bid]) ? '' : ' sg-badge-faded');
-                $badge_list .= '<a href="/node/' . $bid . '" target="_blank">' .
-                              '<img class="sg-admin-badge ' . $faded_class . '" src="/files/badge-derivs/100/' . $node->field_badge_image->entity->getFilename() . '">' .
+                $badge_list .= '<a href="/node/' . $bid . '" target="_blank" title="'.$node->getTitle().'">' .
+                              '<img class="sg-admin-badge ' . $faded_class . '" src="/files/badge-derivs/100/' . $node->field_badge_image->entity->getFilename() . '" alt="Badge image for '.$node->getTitle().'">' .
                               '</a>';
               }
               $badge_count = $db->query("SELECT COUNT(bid) AS bid_count FROM sg_players_badges WHERE pid=:pid AND bid IN (" . implode(',', $bids) . ")", [':pid' => $pid])->fetch();

--- a/templates/byteclub-header.html.twig
+++ b/templates/byteclub-header.html.twig
@@ -1,5 +1,5 @@
 <div class="byteclub-top-menu">
-      <a class="bc-logo" href="/byteclub"><img src="/modules/custom/summergame/images/byteclub-logo.svg" /></a>
+      <a class="bc-logo" href="/byteclub" title="Byte Club Logo"><img src="/modules/custom/summergame/images/byteclub-logo.svg" alt="Byte Club Logo" /></a>
       <a class="bc-link" href="/byteclub_get_started">GETTING STARTED</a>
       <a class="bc-link" href="/byteclub_coming_soon">CONTRIBUTIONS</a>
       <a class="bc-link" href="/byteclub_bits">BITS</a>


### PR DESCRIPTION
- Add title and alt text to badge images in badge list on badge page
- Add alt text to images in ledger entries.  The alt text added is generic as there is not enough info present when rendering to use the node title.  loading the full bib info would be a pretty big performance hit and since the alt text will be available by navigating through and the 100x100 image itself is also too small for a detailed understanding by sight, I'm considering this sufficient.