### PR TITLE
Turn off autofocus for code redeem form on badge pages

### DIFF
--- a/src/Form/SummerGamePlayerRedeemForm.php
+++ b/src/Form/SummerGamePlayerRedeemForm.php
@@ -23,7 +23,7 @@ class SummerGamePlayerRedeemForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $pid = 0) {
+  public function buildForm(array $form, FormStateInterface $form_state, $pid = 0, $autofocus = true) {
     $player = summergame_player_load($pid);
 
     $form = [
@@ -44,8 +44,11 @@ class SummerGamePlayerRedeemForm extends FormBase {
       '#default_value' => ($_GET['text'] ?? ''),
       '#prefix' => '<div class="container-inline">',
       '#suffix' => '</div>',
-      '#attributes' => ['autofocus' => '', 'autocomplete'=>'off', 'autocorrect'=>'off', 'autocapitalize'=>'off', 'spellcheck'=>'false']
+      '#attributes' => [ 'autocomplete'=>'off', 'autocorrect'=>'off', 'autocapitalize'=>'off', 'spellcheck'=>'false']
     ];
+    if ($autofocus){
+      $form['code_text']['#attributes']['autofocus'] = '';
+    }
     $all_players = summergame_player_load_all($player['uid']);
     if (count($all_players) > 1) {
       $pid_options = [];

--- a/src/Helper/BadgeRenderer.php
+++ b/src/Helper/BadgeRenderer.php
@@ -96,7 +96,7 @@ class BadgeRenderer {
             $variables['self_award_form'] = \Drupal::formBuilder()->getForm('Drupal\summergame\Form\SummerGameSelfAwardForm', $pid, $bid);
           }
           else {
-            $variables['redeem_form'] = \Drupal::formBuilder()->getForm('Drupal\summergame\Form\SummerGamePlayerRedeemForm', $pid);
+            $variables['redeem_form'] = \Drupal::formBuilder()->getForm('Drupal\summergame\Form\SummerGamePlayerRedeemForm', $pid, false);
           }
 
           // Handle hidden badges


### PR DESCRIPTION
Adds a configurable parameter to the code redeem form to toggle autofocus off.  defaults to autofocus.  implement on badge rendering

Solves a service alert: https://newstaff.aadl.org/aadl-forms/2/submissions/331