### PR TITLE
More aggressive points caching

### DIFF
--- a/summergame.module
+++ b/summergame.module
@@ -1369,9 +1369,11 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
         $player_points = $cached_points['player_points'];
         //deload badges and grab them fresh, deload game terms if filtering
         foreach ($player_points as $badge_game_term => $data) {
+          /** 
+           * We can also cache badges since the sg_players_badges field has a timestamp
           if (isset($player_points[$badge_game_term]['badges'])) {
             $player_points[$badge_game_term]['badges'] = [];
-          }
+          }*/
           //unset game terms we don't want here.
           if ($game_term !== '' && $badge_game_term !== $game_term && $badge_game_term !== 'career') {
             unset($player_points[$badge_game_term]);
@@ -1482,7 +1484,7 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   }
 
   // Get old badges
-  $params = [':pid' => $pid];
+  $params = [':pid' => $pid, ':after' => $after];
   $game_term_filter = "";
   $new_game_term_filter = "";
   if ($term_filter) {
@@ -1493,7 +1495,7 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   }
 
   $res = $db->query("SELECT * FROM sg_players_badges, sg_badges " .
-                    "WHERE sg_players_badges.pid = :pid AND sg_players_badges.bid = sg_badges.bid " . $game_term_filter .
+                    "WHERE sg_players_badges.pid = :pid AND sg_players_badges.timestamp > :after AND sg_players_badges.bid = sg_badges.bid " . $game_term_filter .
                     "ORDER BY sg_players_badges.timestamp ASC", $params);
   while ($badge = $res->fetchAssoc()) {
     $game_term = $badge['game_term'];
@@ -1509,7 +1511,7 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   $res = $db->query("SELECT gt.entity_id AS bid, gt.field_badge_game_term_value AS game_term, b.bid AS pbid " .
                     "FROM node__field_badge_game_term gt, sg_players_badges b " .
                     "WHERE gt.entity_id = b.bid " .
-                    "AND b.pid = :pid " . $new_game_term_filter .
+                    "AND b.pid = :pid AND b.timestamp > :after " . $new_game_term_filter .
                     "ORDER BY bid ASC", $params);
   while ($badge = $res->fetchAssoc()) {
     $game_term = $badge['game_term'];

--- a/summergame.module
+++ b/summergame.module
@@ -1341,15 +1341,28 @@ function summergame_get_active_player() {
 function summergame_get_player_points($pid, $game_term = '', $type = '') {
   $term_filter = FALSE;
 
+  $closed_game_terms = \Drupal::config('summergame.settings')->get('summergame_closed_game_terms');
+  $closed_game_term__points_filter = "";
+  $closed_game_term_filter = "";
+  $closed_new_game_term_filter = "";
+
   $player_points = [
     'career' => 0,
   ];
+  
+
+  $refresh = false;
+  if(isset($_GET['refresh'])){
+    $refresh = true;
+  }
 
   //redis setup
   $after = 0;
   $using_cache = false;
+  $using_closed_cache = false;
   $redis = null;
   $cached_points_raw = null;
+  $host = \Drupal::request()->getHost();
   try{
     $redis = new Client(\Drupal::config('summergame.settings')->get('summergame_redis_conn'));
     $redis->connect();
@@ -1357,9 +1370,10 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
     $redis = null;
   }
   
-  if (!is_null($redis)) {
-    $host = \Drupal::request()->getHost();
+  if (!is_null($redis) && !$refresh) {
     $cached_points_raw = $redis->get("$host:summergame:points:$pid");
+    $cached_points_closed_raw = $redis->get("$host:summergame:points_closed:$pid");
+
     if (!is_null($cached_points_raw)) {
       $cached_points = json_decode($cached_points_raw, true);
       if($cached_points['timestamp'] > strtotime('-1 hour',time())){
@@ -1383,6 +1397,20 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
         $redis->del("$host:summergame:points:$pid");
       }
     }
+    //grab closed game terms from closed cache ONLY if we're not using
+    if (!is_null($cached_points_closed_raw) && !$using_cache) {
+      $using_closed_cache = true;
+      $cached_closed_points = json_decode($cached_points_closed_raw , true);
+      $closed_game_term_points_filter = " AND game_term NOT IN (:closed_game_terms[]) ";
+      $closed_game_term_filter = " AND sg_badges.game_term NOT IN (:closed_game_terms[]) ";
+      $closed_new_game_term_filter = " AND gt.field_badge_game_term_value NOT IN (:closed_game_terms[]) ";
+      $after = 0; // just to be explicit that we're not filtering by time
+      foreach ($closed_game_terms as $closed_game_term) {
+        if (isset($cached_closed_points[$closed_game_term])) {
+          $player_points[$closed_game_term] = $cached_closed_points[$closed_game_term];
+        }
+      }
+    }
   }
 
   $query = "SELECT SUM(points) AS total, MIN(timestamp) as min_timestamp,  MAX(timestamp) as max_timestamp, game_term, type, (CASE WHEN metadata LIKE '%leaderboard:no%' THEN 'leaderboard:no' WHEN metadata NOT LIKE '%leaderboard:no%' THEN '' END) as leader from sg_ledger WHERE pid = :pid AND timestamp > :after";
@@ -1397,6 +1425,11 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
     $query .= " AND type = :type";
     $args[':type'] = $type;
   }
+  if ($using_closed_cache) {
+    $query .= $closed_game_term_points_filter;
+    $args[':closed_game_terms[]'] = $closed_game_terms;
+  }
+
   $query .= " group by game_term, type,  (CASE WHEN metadata LIKE '%leaderboard:no%' THEN 'leaderboard:no' WHEN metadata NOT LIKE '%leaderboard:no%' THEN '' END) ORDER BY max_timestamp DESC";
 
   $db = \Drupal::database();
@@ -1454,6 +1487,9 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   if ($term_filter) {
     $query = $query->condition('game_term', $game_term, '=');
   }
+  if ($using_closed_cache) {
+    $query = $query->condition('game_term', $closed_game_terms, 'NOT IN');
+  }
   $query = $query->condition('metadata', 'delete:no leaderboard:no prize_count:%', 'LIKE');
   
 
@@ -1493,9 +1529,12 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
 
     $params[':game_term'] = $game_term;
   }
+  if ($using_closed_cache) {
+    $params[':closed_game_terms[]'] = $closed_game_terms;
+  }
 
   $res = $db->query("SELECT * FROM sg_players_badges, sg_badges " .
-                    "WHERE sg_players_badges.pid = :pid AND sg_players_badges.timestamp > :after AND sg_players_badges.bid = sg_badges.bid " . $game_term_filter .
+                    "WHERE sg_players_badges.pid = :pid AND sg_players_badges.timestamp > :after AND sg_players_badges.bid = sg_badges.bid " . $game_term_filter . $closed_game_term_filter  .
                     "ORDER BY sg_players_badges.timestamp ASC", $params);
   while ($badge = $res->fetchAssoc()) {
     $game_term = $badge['game_term'];
@@ -1511,7 +1550,7 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
   $res = $db->query("SELECT gt.entity_id AS bid, gt.field_badge_game_term_value AS game_term, b.bid AS pbid " .
                     "FROM node__field_badge_game_term gt, sg_players_badges b " .
                     "WHERE gt.entity_id = b.bid " .
-                    "AND b.pid = :pid AND b.timestamp > :after " . $new_game_term_filter .
+                    "AND b.pid = :pid AND b.timestamp > :after " . $new_game_term_filter . $closed_new_game_term_filter  .
                     "ORDER BY bid ASC", $params);
   while ($badge = $res->fetchAssoc()) {
     $game_term = $badge['game_term'];
@@ -1543,6 +1582,13 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
     $redis->setEx("$host:summergame:points:$pid", 3600, json_encode($points_cache_obj));
   }
 
+  //save closed game terms in long running cache
+  if (!$using_closed_cache && $term_filter == FALSE && !is_null($redis)) {
+    $points_closed_cache_obj = [];
+    $points_closed_cache_obj['timestamp'] = time();
+    $points_closed_cache_obj['player_points'] = $player_points;
+    $redis->set("$host:summergame:points_closed:$pid", json_encode($points_closed_cache_obj));
+  }
   return $player_points;
 }
 

--- a/summergame.module
+++ b/summergame.module
@@ -1338,7 +1338,7 @@ function summergame_get_active_player() {
 /**
  * UTILITY: Load player points
  */
-function summergame_get_player_points($pid, $game_term = '', $type = '', $refresh = FALSE) {
+function summergame_get_player_points($pid, $game_term = '', $type = '', $refresh = NULL) {
   $term_filter = FALSE;
 
   $closed_game_terms = \Drupal::config('summergame.settings')->get('summergame_closed_game_terms');
@@ -1350,7 +1350,10 @@ function summergame_get_player_points($pid, $game_term = '', $type = '', $refres
     'career' => 0,
   ];
 
-  if (!empty($refresh) || isset($_GET['refresh'])) {
+  // If function argument is truthy, refresh
+  // OR
+  // if GET var is set and function argument is NOT set to FALSE, refresh
+  if (!empty($refresh) || (isset($_GET['refresh']) && $refresh !== FALSE)) {
     $refresh = TRUE;
   }
 

--- a/summergame.module
+++ b/summergame.module
@@ -1338,7 +1338,7 @@ function summergame_get_active_player() {
 /**
  * UTILITY: Load player points
  */
-function summergame_get_player_points($pid, $game_term = '', $type = '') {
+function summergame_get_player_points($pid, $game_term = '', $type = '', $refresh = null) {
   $term_filter = FALSE;
 
   $closed_game_terms = \Drupal::config('summergame.settings')->get('summergame_closed_game_terms');
@@ -1350,9 +1350,11 @@ function summergame_get_player_points($pid, $game_term = '', $type = '') {
     'career' => 0,
   ];
   
-
-  $refresh = false;
-  if(isset($_GET['refresh'])){
+  
+  if (!is_null($refresh) && $refresh == true) {
+    $refresh = true;
+  }
+  if(isset($_GET['refresh']) && $refresh !== false){
     $refresh = true;
   }
 

--- a/summergame.module
+++ b/summergame.module
@@ -1338,59 +1338,55 @@ function summergame_get_active_player() {
 /**
  * UTILITY: Load player points
  */
-function summergame_get_player_points($pid, $game_term = '', $type = '', $refresh = null) {
+function summergame_get_player_points($pid, $game_term = '', $type = '', $refresh = FALSE) {
   $term_filter = FALSE;
 
   $closed_game_terms = \Drupal::config('summergame.settings')->get('summergame_closed_game_terms');
-  $closed_game_term__points_filter = "";
+  $closed_game_term_points_filter = "";
   $closed_game_term_filter = "";
   $closed_new_game_term_filter = "";
 
   $player_points = [
     'career' => 0,
   ];
-  
-  
-  if (!is_null($refresh) && $refresh == true) {
-    $refresh = true;
-  }
-  if(isset($_GET['refresh']) && $refresh !== false){
-    $refresh = true;
+
+  if (!empty($refresh) || isset($_GET['refresh'])) {
+    $refresh = TRUE;
   }
 
-  //redis setup
+  // redis setup
   $after = 0;
-  $using_cache = false;
-  $using_closed_cache = false;
-  $redis = null;
-  $cached_points_raw = null;
+  $using_cache = FALSE;
+  $using_closed_cache = FALSE;
+  $redis = NULL;
+  $cached_points_raw = NULL;
   $host = \Drupal::request()->getHost();
-  try{
+  try {
     $redis = new Client(\Drupal::config('summergame.settings')->get('summergame_redis_conn'));
     $redis->connect();
   } catch (Predis\Connection\ConnectionException $e) {
-    $redis = null;
+    $redis = NULL;
   }
-  
+
   if (!is_null($redis) && !$refresh) {
     $cached_points_raw = $redis->get("$host:summergame:points:$pid");
     $cached_points_closed_raw = $redis->get("$host:summergame:points_closed:$pid");
 
     if (!is_null($cached_points_raw)) {
-      $cached_points = json_decode($cached_points_raw, true);
-      if($cached_points['timestamp'] > strtotime('-1 hour',time())){
+      $cached_points = json_decode($cached_points_raw, TRUE);
+      if ($cached_points['timestamp'] > strtotime('-1 hour', time())){
         // lets use the cache
-        $using_cache = true;
+        $using_cache = TRUE;
         $after = $cached_points['timestamp'];
         $player_points = $cached_points['player_points'];
         //deload badges and grab them fresh, deload game terms if filtering
         foreach ($player_points as $badge_game_term => $data) {
-          /** 
+          /**
            * We can also cache badges since the sg_players_badges field has a timestamp
           if (isset($player_points[$badge_game_term]['badges'])) {
             $player_points[$badge_game_term]['badges'] = [];
           }*/
-          //unset game terms we don't want here.
+          // unset game terms we don't want here.
           if ($game_term !== '' && $badge_game_term !== $game_term && $badge_game_term !== 'career') {
             unset($player_points[$badge_game_term]);
           }
@@ -1399,10 +1395,10 @@ function summergame_get_player_points($pid, $game_term = '', $type = '', $refres
         $redis->del("$host:summergame:points:$pid");
       }
     }
-    //grab closed game terms from closed cache ONLY if we're not using
+    // grab closed game terms from closed cache ONLY if we're not using
     if (!is_null($cached_points_closed_raw) && !$using_cache) {
-      $using_closed_cache = true;
-      $cached_closed_points = json_decode($cached_points_closed_raw , true);
+      $using_closed_cache = TRUE;
+      $cached_closed_points = json_decode($cached_points_closed_raw , TRUE);
       $closed_game_term_points_filter = " AND game_term NOT IN (:closed_game_terms[]) ";
       $closed_game_term_filter = " AND sg_badges.game_term NOT IN (:closed_game_terms[]) ";
       $closed_new_game_term_filter = " AND gt.field_badge_game_term_value NOT IN (:closed_game_terms[]) ";
@@ -1482,9 +1478,9 @@ function summergame_get_player_points($pid, $game_term = '', $type = '', $refres
   }
 
 
-  //$regexp = 'prize_count:(-?[0-9]+)';
+  // $regexp = 'prize_count:(-?[0-9]+)';
   $query = $db->select('sg_ledger', 'sg_ledger')
-  ->condition('pid', $pid, '=');
+              ->condition('pid', $pid, '=');
   $query = $query->condition('timestamp', $after, '>');
   if ($term_filter) {
     $query = $query->condition('game_term', $game_term, '=');
@@ -1493,7 +1489,6 @@ function summergame_get_player_points($pid, $game_term = '', $type = '', $refres
     $query = $query->condition('game_term', $closed_game_terms, 'NOT IN');
   }
   $query = $query->condition('metadata', 'delete:no leaderboard:no prize_count:%', 'LIKE');
-
 
   $query->fields('sg_ledger', ['metadata', 'game_term']);
 
@@ -1576,7 +1571,7 @@ function summergame_get_player_points($pid, $game_term = '', $type = '', $refres
     $player_points[$game_term]['badges'][] = $badge;
   }
 
-  //save in redis if we're not loading from it to ensure we sometimes still load from points from scratch.  also only save if there is no term filter. regardless of whether we loaded with the cache.
+  // save in redis if we're not loading from it to ensure we sometimes still load from points from scratch.  also only save if there is no term filter. regardless of whether we loaded with the cache.
   if (!$using_cache && $term_filter == FALSE && !is_null($redis)) {
     $points_cache_obj = [];
     $points_cache_obj['timestamp'] = time();
@@ -1584,13 +1579,14 @@ function summergame_get_player_points($pid, $game_term = '', $type = '', $refres
     $redis->setEx("$host:summergame:points:$pid", 3600, json_encode($points_cache_obj));
   }
 
-  //save closed game terms in long running cache
+  // save closed game terms in long running cache
   if (!$using_closed_cache && $term_filter == FALSE && !is_null($redis)) {
     $points_closed_cache_obj = [];
     $points_closed_cache_obj['timestamp'] = time();
     $points_closed_cache_obj['player_points'] = $player_points;
     $redis->set("$host:summergame:points_closed:$pid", json_encode($points_closed_cache_obj));
   }
+
   return $player_points;
 }
 


### PR DESCRIPTION
- Adds badge caching.  Previously the badge data was loaded from scratch every time, now it follows the same pattern as the points, and layers in new badges on top of the cache response.

- Allows for a list of “closed“ game terms in settings.php.  These closed game terms are cached in redis with no expire time and will be used when the regular redis points cache is expired.  This cache is only hit when the regular cache has expired.  Its implemented similar to the regular cache but instead of loading everything else after its timestamp, it loads everything that doesn't match the closed game term list.

- To clear both the closed game term cache and the regular points cache, a player page can be loaded with the query parameter `refresh` and points will be recalculated from scratch, and the caches will be filled.  @ejk are there specific actions that we'd want to trigger recalculation or deleting the points caches for a player?

Closed game terms are defined in the settings.php file like so:
```
$config['summergame.settings']['summergame_closed_game_terms'] = [
'SummerGame2023',
'SummerGame2022',
'SummerGame2021',
'SummerGame2020',
'SummerGame2019',
'SummerGame2018',
'SummerGame2017',
'SummerGame2016',
'SummerGame2015',
'SummerGame2014',
'SummerGame2013',
'SummerGame2012',
'SummerGame2011'
];
```